### PR TITLE
mtx_* and thrd_* macros converted to enumerators

### DIFF
--- a/source/tinycthread.h
+++ b/source/tinycthread.h
@@ -168,16 +168,20 @@ int _tthread_timespec_get(struct timespec *ts, int base);
 #endif
 
 /* Function return values */
-#define thrd_error    0 /**< The requested operation failed */
-#define thrd_success  1 /**< The requested operation succeeded */
-#define thrd_timedout 2 /**< The time specified in the call was reached without acquiring the requested resource */
-#define thrd_busy     3 /**< The requested operation failed because a tesource requested by a test and return function is already in use */
-#define thrd_nomem    4 /**< The requested operation failed because it was unable to allocate memory */
+enum { 
+  thrd_error    = 0, /**< The requested operation failed */
+  thrd_success  = 1, /**< The requested operation succeeded */
+  thrd_timedout = 2, /**< The time specified in the call was reached without acquiring the requested resource */
+  thrd_busy     = 3, /**< The requested operation failed because a tesource requested by a test and return function is already in use */
+  thrd_nomem    = 4, /**< The requested operation failed because it was unable to allocate memory */
+};
 
 /* Mutex types */
-#define mtx_plain     0
-#define mtx_timed     1
-#define mtx_recursive 2
+enum {
+  mtx_plain     = 0,
+  mtx_timed     = 1,
+  mtx_recursive = 2,
+};
 
 /* Mutex */
 #if defined(_TTHREAD_WIN32_)


### PR DESCRIPTION
According to C11, `thrd_success`, `thrd_timedout`, `thrd_busy`, `thrd_nomem`, `thrd_error`, `mtx_plain`, `mtx_recursive` and `mtx_timed` must be enumerators.

This change should have no impact on user codes.

See:
- https://en.cppreference.com/w/c/thread/thrd_errors
- https://en.cppreference.com/w/c/thread/mtx_types